### PR TITLE
Don't compile in direct calls to callback functions

### DIFF
--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -9,18 +9,18 @@ defmodule SpandexPhoenix.Instrumenter do
   def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
     controller = Phoenix.Controller.controller_module(conn)
     action = Phoenix.Controller.action_name(conn)
-    @tracer.start_span("Phoenix.Controller", resource: "#{controller}.#{action}")
+    apply(@tracer, :start_span, ["Phoenix.Controller", [resource: "#{controller}.#{action}"]])
   end
 
   def phoenix_controller_call(:stop, _time_diff, _start_meta) do
-    @tracer.finish_span()
+    apply(@tracer, :finish_span, [])
   end
 
   def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
-    @tracer.start_span("Phoenix.View", resource: view)
+    apply(@tracer, :start_span, ["Phoenix.View", [resource: view]])
   end
 
   def phoenix_controller_render(:stop, _time_diff, _start_meta) do
-    @tracer.finish_span()
+    apply(@tracer, :finish_span, [])
   end
 end


### PR DESCRIPTION
When compiling a project that includes `spandex_phoenix` (in the example below, the `spandex_example` project), it throws a compiler warning because we're compiling-in a direct function call on a module in the application using us as a library (which we obviously don't depend on from `spandex_phoenix`).

Using `apply` gets around this because it's dynamically finding and calling the function at runtime.

```
==> spandex_phoenix
Compiling 1 file (.ex)
warning: function PhoenixBackend.Tracer.finish_span/0 is undefined (module PhoenixBackend.Tracer is not available)
Found at 2 locations:
  lib/spandex_phoenix/instrumenter.ex:16
  lib/spandex_phoenix/instrumenter.ex:24

warning: function PhoenixBackend.Tracer.start_span/2 is undefined (module PhoenixBackend.Tracer is not available)
Found at 2 locations:
  lib/spandex_phoenix/instrumenter.ex:12
  lib/spandex_phoenix/instrumenter.ex:20
```