### PR TITLE
Require at least Plug 1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule SpandexPhoenix.MixProject do
       {:git_ops, "~> 0.3.3", only: :dev},
       {:inch_ex, github: "rrrene/inch_ex", only: [:dev, :test]},
       {:phoenix, "~> 1.0", optional: true, only: [:dev, :test]},
-      {:plug, "~> 1.0"},
+      {:plug, "~> 1.3"},
       {:spandex, "~> 2.2"}
     ]
   end


### PR DESCRIPTION
When integrating `spandex_phoenix` with an older app, we discovered that `Plug.Conn.path_params` didn't exist until Plug 1.3.0.