### PR TITLE
Ensure a conn is always returned

### DIFF
--- a/lib/spandex_phoenix/plug/start_trace.ex
+++ b/lib/spandex_phoenix/plug/start_trace.ex
@@ -31,9 +31,10 @@ defmodule SpandexPhoenix.Plug.StartTrace do
 
   @impl Plug
   def call(conn, opts) do
-    case opts[:filter_traces].(conn) do
-      true -> begin_tracing(conn, opts)
-      false -> conn
+    if opts[:filter_traces].(conn) do
+      begin_tracing(conn, opts)
+    else
+      conn
     end
   end
 

--- a/lib/spandex_phoenix/plug/start_trace.ex
+++ b/lib/spandex_phoenix/plug/start_trace.ex
@@ -31,8 +31,9 @@ defmodule SpandexPhoenix.Plug.StartTrace do
 
   @impl Plug
   def call(conn, opts) do
-    if opts[:filter_traces].(conn) do
-      begin_tracing(conn, opts)
+    case opts[:filter_traces].(conn) do
+      true -> begin_tracing(conn, opts)
+      false -> conn
     end
   end
 

--- a/test/plug/start_trace_test.exs
+++ b/test/plug/start_trace_test.exs
@@ -45,6 +45,17 @@ defmodule StartTracePlugTest do
       assert {:ok, %Spandex.SpanContext{}} = TestTracer.current_context()
     end
 
+    test "returns a connection when a provided filter_traces function returns a false value" do
+      defmodule NoTraceFilter do
+        def filter_traces(_conn) do
+          false
+        end
+      end
+
+      conn = call(StartTrace, :head, "/", filter_traces: &NoTraceFilter.filter_traces/1)
+      assert %Plug.Conn{} = conn
+    end
+
     test "defaults the root span name to 'request'" do
       call(StartTrace, :get, "/", [])
       assert %Spandex.Span{name: "request"} = TestTracer.current_span()


### PR DESCRIPTION
When overriding the default `:filter_traces/1` function, specifically when returning false an error occurs.
This is due to the fact that the StartTrace plug `call` function only returns a `conn` for cases when
`filter_traces/1` returns true.

The error happens at the `Plug.Conn.register_before_send/2` function as no `conn` is being passed:

```
** (FunctionClauseError) no function clause matching in Plug.Conn.register_before_send/2
```