### PR TITLE
chore: fix small typespec issue

### DIFF
--- a/test/support/test_adapter.ex
+++ b/test/support/test_adapter.ex
@@ -3,7 +3,7 @@ defmodule TestAdapter do
   @behaviour Spandex.Adapter
 
   require Logger
-  alias Spandex.SpanContext
+  alias Spandex.{SpanContext, Tracer}
 
   @max_id 9_223_372_036_854_775_807
 


### PR DESCRIPTION
The type `Tracer.opts` is used later on in the file, but `Tracer` is not aliased.