### PR TITLE
use URI.decode in resource reverse engineering

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -244,15 +244,14 @@ defmodule SpandexPhoenix do
 
   # Phoenix doesn't set the plug_route for us, so we have to figure it out ourselves
   defp route_name(%Plug.Conn{path_params: path_params, path_info: path_info}) do
-    inverted_params = Enum.map(path_params, fn {k, v} -> {v, k} end)
-    "/" <> Enum.map_join(path_info, "/", &replace_path_param_with_name(inverted_params, &1))
+    "/" <> Enum.map_join(path_info, "/", &replace_path_param_with_name(path_params, &1))
   end
 
-  defp replace_path_param_with_name(inverted_params, path_component) do
+  defp replace_path_param_with_name(path_params, path_component) do
     decoded_component = URI.decode(path_component)
 
-    Enum.find_value(inverted_params, decoded_component, fn
-      {^decoded_component, param_name} -> ":#{param_name}"
+    Enum.find_value(path_params, decoded_component, fn
+      {param_name, ^decoded_component} -> ":#{param_name}"
       _ -> nil
     end)
   end

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -254,7 +254,7 @@ defmodule SpandexPhoenix do
   defp replace_path_param_with_name(inverted_params, path_component) do
     decoded_component = URI.decode(path_component)
 
-    Enum.find_value(inverted_params, fn 
+    Enum.find_value(inverted_params, fn
       {^decoded_component, param_name} -> ":#{param_name}"
       _ -> nil
     end, decoded_component)

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -183,10 +183,7 @@ defmodule SpandexPhoenix do
   def default_metadata(conn) do
     conn = Plug.Conn.fetch_query_params(conn)
 
-    route =
-      conn
-      |> route_name()
-      |> URI.decode_www_form()
+    route = route_name(conn)
 
     user_agent =
       conn
@@ -200,7 +197,7 @@ defmodule SpandexPhoenix do
         method: method,
         query_string: conn.query_string,
         status_code: conn.status,
-        url: URI.decode_www_form(conn.request_path),
+        url: URI.decode(conn.request_path),
         user_agent: user_agent
       ],
       resource: method <> " " <> route,

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -254,9 +254,9 @@ defmodule SpandexPhoenix do
   defp replace_path_param_with_name(inverted_params, path_component) do
     decoded_component = URI.decode(path_component)
 
-    Enum.find_value(inverted_params, fn
+    Enum.find_value(inverted_params, decoded_component, fn
       {^decoded_component, param_name} -> ":#{param_name}"
       _ -> nil
-    end, decoded_component)
+    end)
   end
 end

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -252,11 +252,11 @@ defmodule SpandexPhoenix do
   end
 
   defp replace_path_param_with_name(inverted_params, path_component) do
-    decoded_component = URI.decode_www_form(path_component)
+    decoded_component = URI.decode(path_component)
 
-    case Enum.find(inverted_params, fn {param_value, _param_name} -> param_value == decoded_component end) do
-      nil -> decoded_component
-      {_param_value, param_name} -> ":#{param_name}"
-    end
+    Enum.find_value(inverted_params, fn 
+      {^decoded_component, param_name} -> ":#{param_name}"
+      _ -> nil
+    end, decoded_component)
   end
 end

--- a/test/tracer_integration/phoenix/endpoint_test.exs
+++ b/test/tracer_integration/phoenix/endpoint_test.exs
@@ -232,7 +232,7 @@ defmodule TracerWithPhoenixEndpointTest do
 
     test "handles non-ASCII characters in path params" do
       assert capture_log(fn ->
-               call(Endpoint, :get, "/hello/%f0%9f%a4%af")
+               call(Endpoint, :get, "/hello/+%f0%9f%a4%af")
              end) =~ ~r|Processing with TracerWithPhoenixEndpointTest.Controller.hello/2|
 
       assert_receive {
@@ -247,7 +247,7 @@ defmodule TracerWithPhoenixEndpointTest do
         }
       }
 
-      assert Keyword.get(http, :url) == "/hello/🤯"
+      assert Keyword.get(http, :url) == "/hello/+🤯"
     end
 
     test "validates the options passed to the use macro" do


### PR DESCRIPTION
Ref #8, problem numero tres

- also obnoxiously replaces an Enum.find with Enum.find_value

I can rollback that unnecessary refactor, sometimes I just can't help myself :P it happened in my head as I was trying to understand what was going on there.

