### PR TITLE
Normalize Phoenix.NoRouteErrors into a single resource name

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -233,14 +233,22 @@ defmodule SpandexPhoenix do
         _ -> %RuntimeError{message: Exception.format_banner(kind, reason)}
       end
 
-    tracer.span_error(exception, stack)
-    tracer.update_span(error: [error?: true])
-
+    mark_span_as_error(tracer, exception, stack)
     FinishTrace.call(conn, finish_opts)
     :erlang.raise(kind, reason, stack)
   end
 
   # Private Helpers
+
+  defp mark_span_as_error(tracer, exception, stack) do
+    # Normalize the span name for urls with no resource
+    if match?(%Phoenix.Router.NoRouteError{}, exception) do
+      tracer.update_span(resource: "Not Found")
+    end
+
+    tracer.span_error(exception, stack)
+    tracer.update_span(error: [error?: true])
+  end
 
   # Set by Plug.Router
   defp route_name(%Plug.Conn{private: %{plug_route: {route, _fn}}}), do: route


### PR DESCRIPTION
When there's no resource for a url, renames the span to Not Found, normalizing all the wild urls drive-by spammers hit with

See https://github.com/spandex-project/spandex_phoenix/issues/8#issuecomment-459604209