### PR TITLE
Minor doc fix regarding `filter_traces`

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -38,7 +38,7 @@ defmodule SpandexPhoenix do
       ```elixir
       defmodule MyAppWeb.Endpoint do
         use Phoenix.Endpoint, otp_app: :my_app
-        use SpandexPhoenix, filter_traces: &filter_traces/1
+        use SpandexPhoenix, filter_traces: &__MODULE__.filter_traces/1
 
         def filter_traces(conn) do
           conn.method in ~w(DELETE GET POST PUT)


### PR DESCRIPTION
Updates the code sample to be consistent with the "NOTE:" below it regarding using `&__MODULE__.function_name/1` for functions in the current module.