### PR TITLE
Made phoenix dependency non-optional

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -237,12 +237,11 @@ defmodule SpandexPhoenix do
 
   # Private Helpers
 
-  defp mark_span_as_error(tracer, exception, stack) do
-    # Normalize the span name for urls with no resource
-    if Code.ensure_loaded?(Phoenix) && Map.get(exception, :__struct__) == Phoenix.Router.NoRouteError do
-      tracer.update_span(resource: "Not Found")
-    end
+  defp mark_span_as_error(tracer, %{__struct__: Phoenix.Router.NoRouteError, __exception__: true}, _stack) do
+    tracer.update_span(resource: "Not Found")
+  end
 
+  defp mark_span_as_error(tracer, exception, stack) do
     tracer.span_error(exception, stack)
     tracer.update_span(error: [error?: true])
   end

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -239,7 +239,7 @@ defmodule SpandexPhoenix do
 
   defp mark_span_as_error(tracer, exception, stack) do
     # Normalize the span name for urls with no resource
-    if match?(%Phoenix.Router.NoRouteError{}, exception) do
+    if Code.ensure_loaded?(Phoenix.Router.NoRouteError) && match?(%Phoenix.Router.NoRouteError{}, exception) do
       tracer.update_span(resource: "Not Found")
     end
 

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -239,7 +239,7 @@ defmodule SpandexPhoenix do
 
   defp mark_span_as_error(tracer, exception, stack) do
     # Normalize the span name for urls with no resource
-    if Code.ensure_loaded?(Phoenix.Router.NoRouteError) && Map.get(exception, :__struct__) == Phoenix.Router.NoRouteError do
+    if Code.ensure_loaded?(Phoenix) && Map.get(exception, :__struct__) == Phoenix.Router.NoRouteError do
       tracer.update_span(resource: "Not Found")
     end
 

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -239,7 +239,7 @@ defmodule SpandexPhoenix do
 
   defp mark_span_as_error(tracer, exception, stack) do
     # Normalize the span name for urls with no resource
-    if Code.ensure_loaded?(Phoenix.Router.NoRouteError) && match?(%Phoenix.Router.NoRouteError{}, exception) do
+    if Code.ensure_loaded?(Phoenix.Router.NoRouteError) && Map.get(exception, :__struct__) == Phoenix.Router.NoRouteError do
       tracer.update_span(resource: "Not Found")
     end
 

--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -1,49 +1,55 @@
-if Code.ensure_loaded?(Phoenix) do
-  defmodule SpandexPhoenix.Instrumenter do
-    @moduledoc """
-    Phoenix instrumenter callback module to automatically create spans for
-    Phoenix Controller and View information.
+defmodule SpandexPhoenix.Instrumenter do
+  @moduledoc """
+  Phoenix instrumenter callback module to automatically create spans for
+  Phoenix Controller and View information.
 
-    Configure your Phoenix `Endpoint` to use this library as one of its
-    `instrumenters`:
+  Configure your Phoenix `Endpoint` to use this library as one of its
+  `instrumenters`:
 
-    ```elixir
-    config :my_app, MyAppWeb.Endpoint,
-      # ... existing config ...
-      instrumenters: [SpandexPhoenix.Instrumenter]
-    ```
+  ```elixir
+  config :my_app, MyAppWeb.Endpoint,
+    # ... existing config ...
+    instrumenters: [SpandexPhoenix.Instrumenter]
+  ```
 
-    More details can be found in [the Phoenix documentation].
+  More details can be found in [the Phoenix documentation].
 
-    [the Phoenix documentation]: https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-phoenix-default-events
-    """
+  [the Phoenix documentation]: https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-phoenix-default-events
+  """
 
-    @tracer_not_configured_msg "You must configure a :tracer for :spandex_phoenix"
+  @tracer_not_configured_msg "You must configure a :tracer for :spandex_phoenix"
 
-    @doc false
-    def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
-      tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+  @doc false
+  def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
+    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+    apply(tracer, :start_span, ["Phoenix.Controller", [resource: controller_resource_name(conn)]])
+  end
+
+  @doc false
+  def phoenix_controller_call(:stop, _time_diff, _start_meta) do
+    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+    apply(tracer, :finish_span, [])
+  end
+
+  @doc false
+  def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
+    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+    apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
+  end
+
+  @doc false
+  def phoenix_controller_render(:stop, _time_diff, _start_meta) do
+    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+    apply(tracer, :finish_span, [])
+  end
+
+  defp controller_resource_name(conn) do
+    if Code.ensure_loaded?(Phoenix) do
       controller = Phoenix.Controller.controller_module(conn)
       action = Phoenix.Controller.action_name(conn)
-      apply(tracer, :start_span, ["Phoenix.Controller", [resource: "#{controller}.#{action}"]])
-    end
-
-    @doc false
-    def phoenix_controller_call(:stop, _time_diff, _start_meta) do
-      tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
-      apply(tracer, :finish_span, [])
-    end
-
-    @doc false
-    def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
-      tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
-      apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
-    end
-
-    @doc false
-    def phoenix_controller_render(:stop, _time_diff, _start_meta) do
-      tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
-      apply(tracer, :finish_span, [])
+      "#{controller}.#{action}"
+    else
+      "unknown.unknown"
     end
   end
 end


### PR DESCRIPTION
Hi,

we're having trouble properly compiling `spandex_phoenix` because it's `phoenix` is currently marked an an optional dependency but does not actually compile without `phoenix`, since it references `Phoenix.Router.NoRouteError`.

Specifically, we see the following error:

```
== Compilation error in file lib/spandex_phoenix.ex ==
** (CompileError) lib/spandex_phoenix.ex:242: Phoenix.Router.NoRouteError.__struct__/0 is undefined, cannot expand struct Phoenix.Router.NoRouteError
    (stdlib) lists.erl:1354: :lists.mapfoldl/3
    (elixir) expanding macro: Kernel.match?/2
could not compile dependency :spandex_phoenix, "mix compile" failed. You can recompile this dependency with "mix deps.compile spandex_phoenix", update it with "mix deps.update spandex_phoenix" or clean it with "mix deps.clean spandex_phoenix"
```

Since `spandex_phoenix` is specifically for `phoenix` integration, can we just make this a non-optional dependency?