### PR TITLE
add a usable instrumenter for better configuration

### DIFF
--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -43,26 +43,30 @@ defmodule SpandexPhoenix.Instrumenter do
   @tracer_not_configured_msg "You must configure a :tracer for :spandex_phoenix"
 
   @doc false
-  def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
-    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+  def phoenix_controller_call(action, meta, data, opts \\ [])
+
+  def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}, opts) do
+    tracer = opts[:tracer] || Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
     apply(tracer, :start_span, ["Phoenix.Controller", [resource: controller_resource_name(conn)]])
   end
 
   @doc false
-  def phoenix_controller_call(:stop, _time_diff, _start_meta) do
-    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+  def phoenix_controller_call(:stop, _time_diff, _start_meta, opts) do
+    tracer = opts[:tracer] || Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
     apply(tracer, :finish_span, [])
   end
 
   @doc false
-  def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
-    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+  def phoenix_controller_render(action, meta, data, opts \\ [])
+
+  def phoenix_controller_render(:start, _compiled_meta, %{view: view}, opts) do
+    tracer = opts[:tracer] || Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
     apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
   end
 
   @doc false
-  def phoenix_controller_render(:stop, _time_diff, _start_meta) do
-    tracer = Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
+  def phoenix_controller_render(:stop, _time_diff, _start_meta, opts) do
+    tracer = opts[:tracer] || Application.get_env(:spandex_phoenix, :tracer) || raise(@tracer_not_configured_msg)
     apply(tracer, :finish_span, [])
   end
 

--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -25,19 +25,19 @@ defmodule SpandexPhoenix.Instrumenter do
 
       @doc false
       def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
-        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :start_span, ["Phoenix.Controller", [resource: controller_resource_name(conn)]])
       end
 
       @doc false
       def phoenix_controller_call(:stop, _time_diff, _start_meta) do
-        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :finish_span, [])
       end
 
       @doc false
       def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
-        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
       end
 

--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -17,6 +17,48 @@ defmodule SpandexPhoenix.Instrumenter do
   [the Phoenix documentation]: https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-phoenix-default-events
   """
 
+  defmacro __using__(opts) do
+    quote bind_quoted: [tracer: opts[:tracer], otp_app: opts[:otp_app]] do
+      unless tracer || otp_app do
+        raise "You must configure a tracer or an otp_app in #{__MODULE__}"
+      end
+
+      @doc false
+      def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
+        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        apply(tracer, :start_span, ["Phoenix.Controller", [resource: controller_resource_name(conn)]])
+      end
+
+      @doc false
+      def phoenix_controller_call(:stop, _time_diff, _start_meta) do
+        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        apply(tracer, :finish_span, [])
+      end
+
+      @doc false
+      def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
+        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
+      end
+
+      @doc false
+      def phoenix_controller_render(:stop, _time_diff, _start_meta) do
+        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        apply(tracer, :finish_span, [])
+      end
+
+      defp controller_resource_name(conn) do
+        if Code.ensure_loaded?(Phoenix) do
+          controller = Phoenix.Controller.controller_module(conn)
+          action = Phoenix.Controller.action_name(conn)
+          "#{controller}.#{action}"
+        else
+          "unknown.unknown"
+        end
+      end
+    end
+  end
+
   @tracer_not_configured_msg "You must configure a :tracer for :spandex_phoenix"
 
   @doc false

--- a/lib/spandex_phoenix/instrumenter.ex
+++ b/lib/spandex_phoenix/instrumenter.ex
@@ -23,27 +23,32 @@ defmodule SpandexPhoenix.Instrumenter do
         raise "You must configure a tracer or an otp_app in #{__MODULE__}"
       end
 
+      @tracer tracer
+      @otp_app otp_app
+
       @doc false
       def phoenix_controller_call(:start, _compiled_meta, %{conn: conn}) do
-        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = @tracer || Application.get_env(@otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :start_span, ["Phoenix.Controller", [resource: controller_resource_name(conn)]])
       end
 
       @doc false
       def phoenix_controller_call(:stop, _time_diff, _start_meta) do
-        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = @tracer || Application.get_env(@otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :finish_span, [])
       end
 
       @doc false
       def phoenix_controller_render(:start, _compiled_meta, %{view: view}) do
-        tracer = tracer || Application.get_env(otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer = @tracer || Application.get_env(@otp_app, __MODULE__)[:tracer] || raise(@tracer_not_configured_msg)
         apply(tracer, :start_span, ["Phoenix.View", [resource: view]])
       end
 
       @doc false
       def phoenix_controller_render(:stop, _time_diff, _start_meta) do
-        tracer = tracer || Application.get_env(otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+        tracer =
+          @tracer || Application.get_env(@otp_app, :spandex_phoenix)[:tracer] || raise(@tracer_not_configured_msg)
+
         apply(tracer, :finish_span, [])
       end
 


### PR DESCRIPTION
With this you can define your own instrumenter and customize either the `otp_app` or the `tracer` when doing so:

```
defmodule MyApp.SpandexInstrumenter do
  use Spandex.Instrumenter, otp_app: :my_app

  # OR

  use Spandex.Instrumenter, tracer: MyApp.Tracer
end
```

Resolves #20 