### PR TITLE
Better calculate the route for the resource name

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -252,8 +252,6 @@ defmodule SpandexPhoenix do
   # Phoenix doesn't set the plug_route for us, so we have to figure it out ourselves
   defp route_name(%Plug.Conn{path_params: path_params, request_path: request_path}) do
     path = URI.decode(request_path)
-
-    path_params
-    |> Enum.reduce(path, fn {param, value}, acc -> String.replace(acc, value, ":#{param}") end)
+    Enum.reduce(path_params, path, fn {param, value}, acc -> String.replace(acc, value, ":#{param}") end)
   end
 end

--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -250,16 +250,10 @@ defmodule SpandexPhoenix do
   defp route_name(%Plug.Conn{private: %{plug_route: {route, _fn}}}), do: route
 
   # Phoenix doesn't set the plug_route for us, so we have to figure it out ourselves
-  defp route_name(%Plug.Conn{path_params: path_params, path_info: path_info}) do
-    "/" <> Enum.map_join(path_info, "/", &replace_path_param_with_name(path_params, &1))
-  end
+  defp route_name(%Plug.Conn{path_params: path_params, request_path: request_path}) do
+    path = URI.decode(request_path)
 
-  defp replace_path_param_with_name(path_params, path_component) do
-    decoded_component = URI.decode(path_component)
-
-    Enum.find_value(path_params, decoded_component, fn
-      {param_name, ^decoded_component} -> ":#{param_name}"
-      _ -> nil
-    end)
+    path_params
+    |> Enum.reduce(path, fn {param, value}, acc -> String.replace(acc, value, ":#{param}") end)
   end
 end


### PR DESCRIPTION
Right now, the calculcation of the routes strips static
parts of the path when calculating the resource name

For instance if you have the following route:

```
scope "/carts" do
  forward "/cart", Routers.CartRouter
end
```

and in the CartRouter
```
scope "/", ApiV1Web do
  get "/:app_id/:identifier", CartController, :get
end
```

the request path would be something like `/carts/cart/1234/abc`. This
would get send with a resource name of `GET /:app_id/:identifier`, which
make is very hard to differentiate between routes in a different
router or scope.

This change preserves the static parts of the route so that a clearer
route name is obtained.