### PR TITLE
Handle Plug.Parsers.UnsupportedMediaTypeError

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -244,6 +244,9 @@ defmodule SpandexPhoenix do
     tracer.update_span(resource: "Not Found")
   end
 
+  def mark_span_as_error(_tracer, %{__struct__: Plug.Parsers.UnsupportedMediaTypeError, __exception__: true}, _stack),
+    do: nil
+
   def mark_span_as_error(tracer, exception, stack) do
     tracer.span_error(exception, stack)
     tracer.update_span(error: [error?: true])

--- a/test/support/router_helper.ex
+++ b/test/support/router_helper.ex
@@ -2,8 +2,14 @@ defmodule RouterHelper do
   @moduledoc false
 
   def call(router, verb, path, opts \\ []) do
-    verb
-    |> Plug.Test.conn(path)
-    |> router.call(router.init(opts))
+    conn = Plug.Test.conn(verb, path)
+
+    conn =
+      case Keyword.get(opts, :content_type) do
+        nil -> conn
+        content_type -> Plug.Conn.put_req_header(conn, "content-type", content_type)
+      end
+
+    router.call(conn, router.init(opts))
   end
 end


### PR DESCRIPTION
Fixes #40.

`Plug.Parsers.UnsupportedMediaTypeError` is raised when `Plug.Parsers` doesn't support the content-type specified in the request.

Similarly to `Phoenix.Router.NoRouteError`, this shouldn't be treated as an error span, since anyone can send an unsupported media type to the server. Unlike `Phoenix.Router.NoRouteError`, we can keep the resource name.

This change matches the `Plug.Parsers.UnsupportedMediaTypeError` in `SpandexPhoenix.mark_span_as_error/3` and skips marking the trace as an error.

Here's a sneak peek from our production monitoring where the change was already applied:

![Screenshot_2020-10-19 APM Traces Datadog(1)](https://user-images.githubusercontent.com/801356/96444725-0bfef600-120f-11eb-9f30-2349dad9f904.png)
