### PR TITLE
fix: function :function_clause.__struct__/0 is undefined

### DIFF
--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -147,8 +147,12 @@ defmodule SpandexPhoenix.Telemetry do
   end
 
   def handle_router_event([:phoenix, :router_dispatch, :exception], _, meta, %{tracer: tracer}) do
-    # phx 1.5.3 has a breaking change that switches `:error` to `:reason`
-    error = meta[:reason] || meta[:error]
+    # phx 1.5.3 has a breaking change that switches `:error` to `:reason` + `:kind`
+    error =
+      case meta do
+        %{reason: reason, kind: kind} -> Exception.normalize(kind, reason)
+        %{error: error} -> error
+      end
 
     # :phoenix :router_dispatch :exception has far fewer keys in its metadata
     # (just `kind`, `error/reason`, and `stacktrace`)


### PR DESCRIPTION
This error happens when exception is raised from absinthe

```
[error] Task #PID<0.3034.0> started from SpandexDatadog.ApiServer terminating
** (UndefinedFunctionError) function :function_clause.__struct__/0 is undefined (module :function_clause is not available)
    :function_clause.__struct__()
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:271: SpandexDatadog.ApiServer.add_error_type/2
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:264: SpandexDatadog.ApiServer.add_error_data/2
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:244: SpandexDatadog.ApiServer.meta/1
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:230: SpandexDatadog.ApiServer.format/3
    (elixir 1.11.2) lib/enum.ex:1399: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.11.2) lib/enum.ex:1399: Enum."-map/2-lists^map/1-0-"/2
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:196: SpandexDatadog.ApiServer.send_and_log/2
    (spandex_datadog 1.0.0) lib/spandex_datadog/api_server.ex:172: anonymous fn/3 in SpandexDatadog.ApiServer.handle_call/3
    (elixir 1.11.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: #Function<14.89247124/0 in SpandexDatadog.ApiServer.handle_call/3>
    Args: []
```