### PR TITLE
Remove usage of the transitive dependency Optimal

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -114,10 +114,6 @@ defmodule SpandexPhoenix do
     StartTrace
   }
 
-  @use_opts_schema StartTrace.__schema__()
-                   |> Optimal.merge(AddContext.__schema__())
-                   |> Optimal.merge(FinishTrace.__schema__())
-
   defmacro __using__(opts) do
     tracer = Keyword.get(opts, :tracer, Application.get_env(:spandex_phoenix, :tracer))
     if is_nil(tracer), do: raise("You must configure a :tracer for :spandex_phoenix")
@@ -135,7 +131,6 @@ defmodule SpandexPhoenix do
             finish_opts: finish_opts
           ] do
       @before_compile SpandexPhoenix
-      @after_compile SpandexPhoenix
       @use_opts use_opts
       @tracer tracer
       @start_opts StartTrace.init(start_opts)
@@ -167,13 +162,6 @@ defmodule SpandexPhoenix do
         end
       end
     end
-  end
-
-  # This needs to happen in __after_compile__ so that it's possible to
-  # reference a callback function referenced in the module itself without
-  # getting a validation error.
-  defmacro __after_compile__(%{module: module}, _bytecode) do
-    Optimal.validate!(Module.get_attribute(module, :use_opts), @use_opts_schema)
   end
 
   @doc """

--- a/lib/spandex_phoenix/plug/add_context.ex
+++ b/lib/spandex_phoenix/plug/add_context.ex
@@ -3,34 +3,13 @@ defmodule SpandexPhoenix.Plug.AddContext do
 
   @behaviour Plug
 
-  @init_opts Optimal.schema(
-               opts: [
-                 customize_metadata: {:function, 1},
-                 tracer: :atom
-               ],
-               defaults: [
-                 customize_metadata: &SpandexPhoenix.default_metadata/1,
-                 tracer: Application.get_env(:spandex_phoenix, :tracer)
-               ],
-               describe: [
-                 customize_metadata: """
-                 A function that takes the Plug.Conn for the current request
-                 and returns the desired span options to apply to the top-level
-                 span in the trace. The Plug.Conn is normally evaluated just
-                 before the response is sent to the client, to ensure that the
-                 most-accurate metadata can be collected. In cases where there
-                 is an unhandled error, it may only represent the initial
-                 request without any response information.
-                 """,
-                 tracer: "The tracing module to be used to start the trace."
-               ]
-             )
-
-  @doc false
-  def __schema__, do: @init_opts
+  @default_opts [
+    customize_metadata: &SpandexPhoenix.default_metadata/1,
+    tracer: Application.get_env(:spandex_phoenix, :tracer)
+  ]
 
   @impl Plug
-  def init(opts), do: Optimal.validate!(opts, @init_opts)
+  def init(opts), do: Keyword.merge(@default_opts, opts)
 
   @impl Plug
   def call(conn, opts) do

--- a/lib/spandex_phoenix/plug/finish_trace.ex
+++ b/lib/spandex_phoenix/plug/finish_trace.ex
@@ -3,23 +3,12 @@ defmodule SpandexPhoenix.Plug.FinishTrace do
 
   @behaviour Plug
 
-  @init_opts Optimal.schema(
-               opts: [
-                 tracer: :atom
-               ],
-               defaults: [
-                 tracer: Application.get_env(:spandex_phoenix, :tracer)
-               ],
-               describe: [
-                 tracer: "The tracing module to be used to start the trace."
-               ]
-             )
-
-  @doc false
-  def __schema__, do: @init_opts
+  @default_opts [
+    tracer: Application.get_env(:spandex_phoenix, :tracer)
+  ]
 
   @impl Plug
-  def init(opts), do: Optimal.validate!(opts, @init_opts)
+  def init(opts), do: Keyword.merge(@default_opts, opts)
 
   @impl Plug
   def call(conn, opts) do

--- a/lib/spandex_phoenix/plug/start_trace.ex
+++ b/lib/spandex_phoenix/plug/start_trace.ex
@@ -5,29 +5,14 @@ defmodule SpandexPhoenix.Plug.StartTrace do
 
   alias Spandex.SpanContext
 
-  @init_opts Optimal.schema(
-               opts: [
-                 filter_traces: {:function, 1},
-                 span_name: :string,
-                 tracer: :atom
-               ],
-               defaults: [
-                 filter_traces: &SpandexPhoenix.trace_all_requests/1,
-                 span_name: "request",
-                 tracer: Application.get_env(:spandex_phoenix, :tracer)
-               ],
-               describe: [
-                 filter_traces: "A function that takes a Plug.Conn and returns true for requests to be traced.",
-                 span_name: "The name to be used for the top level span.",
-                 tracer: "The tracing module to be used to start the trace."
-               ]
-             )
-
-  @doc false
-  def __schema__, do: @init_opts
+  @default_opts [
+    filter_traces: &SpandexPhoenix.trace_all_requests/1,
+    span_name: "request",
+    tracer: Application.get_env(:spandex_phoenix, :tracer)
+  ]
 
   @impl Plug
-  def init(opts), do: Optimal.validate!(opts, @init_opts)
+  def init(opts), do: Keyword.merge(@default_opts, opts)
 
   @impl Plug
   def call(conn, opts) do

--- a/test/plug/add_context_test.exs
+++ b/test/plug/add_context_test.exs
@@ -101,11 +101,5 @@ defmodule AddContextPlugTest do
       TestTracer.finish_span()
       assert %Spandex.Span{name: "request", resource: "GET /"} = TestTracer.current_span()
     end
-
-    test "raises an exception when unexpected options are set" do
-      assert_raise ArgumentError, "Opt Validation Error: tr4c3r - is not allowed (no extra keys)", fn ->
-        call(AddContext, :get, "/", tr4c3r: AnotherTracer)
-      end
-    end
   end
 end

--- a/test/plug/finish_trace_test.exs
+++ b/test/plug/finish_trace_test.exs
@@ -62,11 +62,5 @@ defmodule FinishTracePlugTest do
         }
       }
     end
-
-    test "raises an exception when unexpected options are set" do
-      assert_raise ArgumentError, "Opt Validation Error: tr4c3r - is not allowed (no extra keys)", fn ->
-        call(FinishTrace, :get, "/", tr4c3r: AnotherTracer)
-      end
-    end
   end
 end

--- a/test/plug/start_trace_test.exs
+++ b/test/plug/start_trace_test.exs
@@ -65,11 +65,5 @@ defmodule StartTracePlugTest do
       call(StartTrace, :get, "/", span_name: "my root span name")
       assert %Spandex.Span{name: "my root span name"} = TestTracer.current_span()
     end
-
-    test "raises an exception when unexpected options are set" do
-      assert_raise ArgumentError, "Opt Validation Error: spam_name - is not allowed (no extra keys)", fn ->
-        call(StartTrace, :get, "/", spam_name: "Eggs.Sausage.Spam")
-      end
-    end
   end
 end

--- a/test/tracer_integration/phoenix/endpoint_test.exs
+++ b/test/tracer_integration/phoenix/endpoint_test.exs
@@ -315,18 +315,5 @@ defmodule TracerWithPhoenixEndpointTest do
 
       assert Keyword.get(http, :url) == "/hello/+🤯"
     end
-
-    test "validates the options passed to the use macro" do
-      Application.put_env(:spandex_phoenix, __MODULE__.EndpointWithInvalidFilterTraces, [])
-
-      assert_raise ArgumentError, "Opt Validation Error: filter_traces - must be of type {:function, 1}", fn ->
-        defmodule EndpointWithInvalidFilterTraces do
-          use Phoenix.Endpoint, otp_app: :spandex_phoenix
-          use SpandexPhoenix, filter_traces: &__MODULE__.customize_metadata/2
-
-          def customize_metadata(conn, _extra_arg), do: []
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Relates to spandex-project/spandex#124. Currently `spandex_phoenix` makes use of Optimal even though it doesn't list it as a dependency - it's only available because `spandex` requires it, and `spandex_phoenix` requires `spandex`. This removes the use of Optimal, as we think it is the way to go for Spandex to be fast.