### PR TITLE
Update docs to help with installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ end
 Configure it to use your desired `Spandex.Tracer` module in `config.exs`:
 
 ```elixir
-config :spandex_phoenix, tracer: MyApp.Tracer
+config :spandex_phoenix,
+  tracer: MyApp.Tracer,
+  service: :my_app_name,
+  adapter: MyApp.Adapter
 ```
 
 ### Usage: Phx >= 1.5 (Telemetry)


### PR DESCRIPTION
Tiny PR updating the installation guide that hopes to help others in a similar situation.

When configuring spandex_phoenix and spandex_datadog it took me a while until the traces started to show in Datadog. Was only after I added service name in `config.exs` that tracing started to work properly.

