### PR TITLE
Add span opts in router dispatch

### DIFF
--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -147,7 +147,7 @@ defmodule SpandexPhoenix.Telemetry do
     end
   end
 
-  def handle_router_event([:phoenix, :router_dispatch, :exception], _, meta, %{tracer: tracer}) do
+  def handle_router_event([:phoenix, :router_dispatch, :exception], _, meta, %{tracer: tracer, span_opts: opts}) do
     # :phoenix :router_dispatch :exception has far fewer keys in its metadata
     # (just `kind`, `error/reason`, and `stacktrace`)
     # so we can't use `phx_controller?` or `filter_traces` to detect if we are tracing
@@ -163,7 +163,7 @@ defmodule SpandexPhoenix.Telemetry do
         end
 
       SpandexPhoenix.mark_span_as_error(tracer, exception, meta.stacktrace)
-      tracer.finish_span()
+      tracer.finish_span(opts)
     end
   end
 

--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -134,9 +134,10 @@ defmodule SpandexPhoenix.Telemetry do
   end
 
   @doc false
-  def handle_router_event([:phoenix, :router_dispatch, :start], _, meta, %{tracer: tracer}) do
+  def handle_router_event([:phoenix, :router_dispatch, :start], _, meta, %{tracer: tracer, span_opts: opts}) do
     if phx_controller?(meta) do
-      tracer.start_span("phx.router_dispatch", resource: "#{meta.plug}.#{meta.plug_opts}")
+      opts_with_resource = Keyword.put(opts, :resource, "#{meta.plug}.#{meta.plug_opts}")
+      tracer.start_span("phx.router_dispatch", opts_with_resource)
     end
   end
 


### PR DESCRIPTION
Hello,

When you associate a different service name for phoenix, the `phx.router_dispatch` has the default service name and not the custom one.

<img width="440" alt="SpandexPhoenix_CurrentBehavior" src="https://user-images.githubusercontent.com/726552/158773741-5dd91177-0d4a-461d-b7ab-9878a20bdb05.png">

The first commit allows to fix that by adding the span opts when the span for `phx.router_dispatch` is started.

<img width="438" alt="SpandexPhoenix_AfterFirstCommit" src="https://user-images.githubusercontent.com/726552/158774071-5c1a6aac-20eb-4adf-bf85-8d9a32f7d11b.png">

In case of an exception, `phx.router_dispatch` uses again the default service name:

<img width="447" alt="SpandexPhoenix_FailRouterDispatch" src="https://user-images.githubusercontent.com/726552/158774861-08b68b5a-9d69-446f-bd48-6a7f5aa27600.png">

The second commit allows to fix that by adding the span opts when the span is finished:

<img width="505" alt="SpandexPhoenix_AfterSecondCommit" src="https://user-images.githubusercontent.com/726552/158774948-76e939a6-655c-4388-9640-d9a696023161.png">

We use this fix in prod and it works well.
