### PR TITLE
fix: Differentiate telemetry handlers using endpoint_prefix so that we can define multiple

### DIFF
--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -92,7 +92,14 @@ defmodule SpandexPhoenix.Telemetry do
       endpoint_prefix ++ [:stop]
     ]
 
-    :telemetry.attach_many("spandex-endpoint-telemetry", endpoint_events, &__MODULE__.handle_endpoint_event/4, opts)
+    handler_id_suffix = "#{Enum.join(endpoint_prefix, "-")}"
+
+    :telemetry.attach_many(
+      "spandex-endpoint-telemetry-#{handler_id_suffix}",
+      endpoint_events,
+      &__MODULE__.handle_endpoint_event/4,
+      opts
+    )
 
     router_events = [
       [:phoenix, :router_dispatch, :start],
@@ -100,7 +107,12 @@ defmodule SpandexPhoenix.Telemetry do
       [:phoenix, :router_dispatch, :exception]
     ]
 
-    :telemetry.attach_many("spandex-router-telemetry", router_events, &__MODULE__.handle_router_event/4, opts)
+    :telemetry.attach_many(
+      "spandex-router-telemetry-#{handler_id_suffix}",
+      router_events,
+      &__MODULE__.handle_router_event/4,
+      opts
+    )
   end
 
   @doc false


### PR DESCRIPTION
We actually have three different endpoints with three different prefixes.  I just tested this change in our app's development enviroment and now we're able to see traces for all of our endpoints, not just the first.