### PR TITLE
chore: migrate from deprecated functions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :spandex_phoenix, tracer: TestTracer
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :git_ops,
   changelog_file: "CHANGELOG.md",

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/lib/spandex_phoenix/plug/add_context.ex
+++ b/lib/spandex_phoenix/plug/add_context.ex
@@ -5,7 +5,7 @@ defmodule SpandexPhoenix.Plug.AddContext do
 
   @default_opts [
     customize_metadata: &SpandexPhoenix.default_metadata/1,
-    tracer: Application.get_env(:spandex_phoenix, :tracer)
+    tracer: Application.compile_env(:spandex_phoenix, :tracer)
   ]
 
   @impl Plug

--- a/lib/spandex_phoenix/plug/finish_trace.ex
+++ b/lib/spandex_phoenix/plug/finish_trace.ex
@@ -4,7 +4,7 @@ defmodule SpandexPhoenix.Plug.FinishTrace do
   @behaviour Plug
 
   @default_opts [
-    tracer: Application.get_env(:spandex_phoenix, :tracer)
+    tracer: Application.compile_env(:spandex_phoenix, :tracer)
   ]
 
   @impl Plug

--- a/lib/spandex_phoenix/plug/start_trace.ex
+++ b/lib/spandex_phoenix/plug/start_trace.ex
@@ -8,7 +8,7 @@ defmodule SpandexPhoenix.Plug.StartTrace do
   @default_opts [
     filter_traces: &SpandexPhoenix.trace_all_requests/1,
     span_name: "request",
-    tracer: Application.get_env(:spandex_phoenix, :tracer)
+    tracer: Application.compile_env(:spandex_phoenix, :tracer)
   ]
 
   @impl Plug

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule SpandexPhoenix.MixProject do
     [
       app: :spandex_phoenix,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: compilers(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
(copy of https://github.com/spandex-project/spandex/pull/144)

Hey there!

I just noticed some deprecation warnings in our codebase caused by spandex and decided to try to tackle them.
Since `compile_env` is only available after 1.10 I also bumped the elixir version, but I'm not sure how you'd want to handle that regarding releases, so feel completely free to ignore/close this if it doesn't fit in :D 

Thanks for the great work ❤️ 