### PR TITLE
improvement: update top span with errors, so service error gets tagged

### DIFF
--- a/lib/spandex_phoenix.ex
+++ b/lib/spandex_phoenix.ex
@@ -228,15 +228,14 @@ defmodule SpandexPhoenix do
 
   @doc false
   def mark_span_as_error(tracer, %{__struct__: Phoenix.Router.NoRouteError, __exception__: true}, _stack) do
-    tracer.update_span(resource: "Not Found")
+    tracer.update_top_span(resource: "Not Found")
   end
 
   def mark_span_as_error(_tracer, %{__struct__: Plug.Parsers.UnsupportedMediaTypeError, __exception__: true}, _stack),
     do: nil
 
   def mark_span_as_error(tracer, exception, stack) do
-    tracer.span_error(exception, stack)
-    tracer.update_span(error: [error?: true])
+    tracer.update_top_span(error: [error?: true, exception: exception, stacktrace: stack])
   end
 
   # Private Helpers


### PR DESCRIPTION
We may want to put this behind a configuration, but as it stands now, an exception does not mark the entire service call as a failure because the exception is in the `router_dispatch` span not the top span.