### PR TITLE
feat: allow to filter traces for router dispatch event in telemetry module

### DIFF
--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -147,14 +147,14 @@ defmodule SpandexPhoenix.Telemetry do
 
   @doc false
   def handle_router_event([:phoenix, :router_dispatch, :start], _, meta, %{tracer: tracer, span_opts: opts} = config) do
-    if phx_controller?(meta) and trace?(meta.conn, config) do
+    if trace?(meta.conn, config) and phx_controller?(meta) do
       opts_with_resource = Keyword.put(opts, :resource, "#{meta.plug}.#{meta.plug_opts}")
       tracer.start_span("phx.router_dispatch", opts_with_resource)
     end
   end
 
   def handle_router_event([:phoenix, :router_dispatch, :stop], _, meta, %{tracer: tracer} = config) do
-    if phx_controller?(meta) and trace?(meta.conn, config) do
+    if trace?(meta.conn, config) and phx_controller?(meta) do
       tracer.finish_span()
     end
   end

--- a/lib/spandex_phoenix/telemetry.ex
+++ b/lib/spandex_phoenix/telemetry.ex
@@ -146,15 +146,15 @@ defmodule SpandexPhoenix.Telemetry do
   end
 
   @doc false
-  def handle_router_event([:phoenix, :router_dispatch, :start], _, meta, %{tracer: tracer, span_opts: opts}) do
-    if phx_controller?(meta) do
+  def handle_router_event([:phoenix, :router_dispatch, :start], _, meta, %{tracer: tracer, span_opts: opts} = config) do
+    if phx_controller?(meta) and trace?(meta.conn, config) do
       opts_with_resource = Keyword.put(opts, :resource, "#{meta.plug}.#{meta.plug_opts}")
       tracer.start_span("phx.router_dispatch", opts_with_resource)
     end
   end
 
-  def handle_router_event([:phoenix, :router_dispatch, :stop], _, meta, %{tracer: tracer}) do
-    if phx_controller?(meta) do
+  def handle_router_event([:phoenix, :router_dispatch, :stop], _, meta, %{tracer: tracer} = config) do
+    if phx_controller?(meta) and trace?(meta.conn, config) do
       tracer.finish_span()
     end
   end


### PR DESCRIPTION
Hi! This is a small PR to allow to use the `filter_traces` function when tracing router events.

I have an application where I need to have 2 endpoint (with their own router / controllers etc.). This is working very well with the endpoint telemetry events since my endpoint use different prefix (ex `[:phoenix, :endpoint, :my-endpoint]` ) and I can pass the `endpoint_telemetry_prefix` options to catch them properly. 

But for the router events, since I'm using `SpandexPhoenix.Telemetry.install/1` twice (one for each endpoint, with different options), I have duplicated traces. 

<img width="960" alt="Screenshot 2023-02-10 at 18 50 15" src="https://user-images.githubusercontent.com/16072194/218162548-3d3875c6-bba3-4b74-b3ab-d810885898e3.png">

I'm not sure my PR is the right approach, it might be a good idea to allow to pass a new options to handle this but I figured that this would include minimal changes to the codebase and might be prefered for this.

Thanks for the great work on this project 😃 🙌 
